### PR TITLE
[TAS-222] Spring security converts session storage in authorizationRequest to Cookie

### DIFF
--- a/src/main/java/kr/co/zeppy/global/configuration/SecurityConfig.java
+++ b/src/main/java/kr/co/zeppy/global/configuration/SecurityConfig.java
@@ -3,6 +3,7 @@ package kr.co.zeppy.global.configuration;
 import kr.co.zeppy.global.jwt.service.JwtService;
 import kr.co.zeppy.global.filter.ExceptionHandlerFilter;
 import kr.co.zeppy.global.jwt.filter.JwtAuthenticationProcessingFilter;
+import kr.co.zeppy.oauth2.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 import kr.co.zeppy.user.repository.UserRepository;
 import kr.co.zeppy.oauth2.handler.OAuth2LoginFailureHandler;
 import kr.co.zeppy.oauth2.handler.OAuth2LoginSuccessHandler;
@@ -57,6 +58,9 @@ public class SecurityConfig {
                 .requestMatchers(AUTH_WHITELIST).permitAll()
             .anyRequest().authenticated())
             .oauth2Login(oauth2Login -> oauth2Login
+                .authorizationEndpoint()
+                .authorizationRequestRepository(new HttpCookieOAuth2AuthorizationRequestRepository())
+                .and()
                 .successHandler(oAuth2LoginSuccessHandler)
                 .failureHandler(oAuth2LoginFailureHandler)
                 .userInfoEndpoint(userInfoEndpoint -> userInfoEndpoint.userService(customOAuth2UserService)));

--- a/src/main/java/kr/co/zeppy/oauth2/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/kr/co/zeppy/oauth2/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,46 @@
+package kr.co.zeppy.oauth2.repository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import kr.co.zeppy.oauth2.utils.CookieUtils;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.util.SerializationUtils;
+import java.util.Base64;
+
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private static final String COOKIE_NAME = "oauth2_auth_request";
+    private static final int COOKIE_EXPIRY_SECONDS = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, COOKIE_NAME)
+                .map(cookie -> deserialize(cookie.getValue(), OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, COOKIE_NAME);
+            return;
+        }
+        String value = serialize(authorizationRequest);
+        CookieUtils.addCookie(response, COOKIE_NAME, value, COOKIE_EXPIRY_SECONDS);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request, HttpServletResponse response) {
+        return loadAuthorizationRequest(request);
+    }
+
+    private static String serialize(Object object) {
+        return Base64.getUrlEncoder().encodeToString(SerializationUtils.serialize(object));
+    }
+
+    private static <T> T deserialize(String string, Class<T> clazz) {
+        return clazz.cast(SerializationUtils.deserialize(Base64.getUrlDecoder().decode(string)));
+    }
+}

--- a/src/main/java/kr/co/zeppy/oauth2/utils/CookieUtils.java
+++ b/src/main/java/kr/co/zeppy/oauth2/utils/CookieUtils.java
@@ -1,0 +1,46 @@
+package kr.co.zeppy.oauth2.utils;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    // 쿠키를 추가하는 메소드
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        cookie.setSecure(true); // HTTPS에서만 쿠키를 전송
+        response.addCookie(cookie);
+    }
+
+    // 특정 이름의 쿠키를 가져오는 메소드
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            return Arrays.stream(cookies)
+                    .filter(cookie -> name.equals(cookie.getName()))
+                    .findFirst();
+        }
+        return Optional.empty();
+    }
+
+    // 쿠키를 삭제하는 메소드
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
…questRepository to cookie

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ x ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/securityCookie -> develop
### 변경 사항
- 분산 환경 웹 서버 환경에서 oauth 로그인 시 사용자의 oauth 로그인이 redirect 시 session이 저장되어있지 않은 다른 was로 향하게 되면 oauth 로그인이 되지 않음
- 초기 해결 방안으로 aws alb에 sticky session 설정을 구성하였음. 하지만 이 방법은 일시적인 방법으로 백엔드 인증 과정을 stateless하게 설계한 초기 의도와 맞지 않아 spring security oauth2AuthorizationRepository에 oauth2AuthorizationRequest 객체를 세션으로 사용하는 것이 아닌 쿠키에 저장하는 방식으로 변경하여 수정
### 테스트 결과 (optional)
- 사진 설명
(사진 업로드)
