### PR TITLE
[ZP-48] 아이디 로그인 코드 수정

### DIFF
--- a/src/main/java/kr/co/zeppy/global/jwt/service/JwtService.java
+++ b/src/main/java/kr/co/zeppy/global/jwt/service/JwtService.java
@@ -72,16 +72,6 @@ public class JwtService {
 
     private final UserRepository userRepository;
 
-    public String createAccessTokenByUsername(String username) {
-        Date now = new Date();
-        return JWT.create()
-                .withSubject(ACCESS_TOKEN_SUBJECT)
-                .withClaim(USERNAME, username)
-                .withIssuedAt(now)
-                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod))
-                .sign(Algorithm.HMAC512(secretKey));
-    }
-
     public String createAccessToken(String userTag) {
         Date now = new Date();
         return JWT.create()
@@ -103,10 +93,10 @@ public class JwtService {
     }
 
 
-    public String setTokenAndUserInfoURLParam(String url, String accessToken, String refreshToken, 
-                String userId, String userTag, String nickName, String userImage, boolean isfirst)
-                                    throws UnsupportedEncodingException {
-        
+    public String setTokenAndUserInfoURLParam(String url, String accessToken, String refreshToken,
+                                              String userId, String userTag, String nickName, String userImage, boolean isfirst)
+            throws UnsupportedEncodingException {
+
         String encodedUserTag = URLEncoder.encode(userTag, UTF_8);
         String encodedNickName = URLEncoder.encode(nickName, UTF_8);
         return UriComponentsBuilder.fromUriString(url)
@@ -172,7 +162,7 @@ public class JwtService {
         return accessToken;
     }
 
-    
+
     public Optional<String> extractUserTagFromToken(String token) {
         return Optional.of(token.replace(BEARER, "").trim())
                 .flatMap(this::extractUserTag);
@@ -191,30 +181,16 @@ public class JwtService {
     }
 
 
-    public Optional<String> extractUsername(String accessToken) {
-        try {
-            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
-                    .build()
-                    .verify(accessToken)
-                    .getClaim(USERNAME)
-                    .asString());
-        } catch (Exception e) {
-            log.error("액세스 토큰이 유효하지 않습니다.");
-            return Optional.empty();
-        }
-    }
-
-    
     public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
         response.setHeader(accessHeader, accessToken);
     }
 
-    
+
     // access token을 response body에 담아서 보냄
     public void setAccessTokenBody(HttpServletResponse response, String accessToken) {
         response.setContentType(APPLICATION_JSON);
         response.setCharacterEncoding(UTF_8);
-    
+
         Map<String, String> tokenMap = new HashMap<>();
         tokenMap.put(accessTokenName, accessToken);
 
@@ -281,7 +257,7 @@ public class JwtService {
             throw new InvalidJwtException(ApplicationError.INVALID_JWT_TOKEN);
         }
     }
-  
+
 
     public String getStringUserIdFromToken(String token) {
         return extractUserTagFromToken(token)

--- a/src/main/java/kr/co/zeppy/login/handler/LoginSuccessHandler.java
+++ b/src/main/java/kr/co/zeppy/login/handler/LoginSuccessHandler.java
@@ -11,6 +11,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 
+import java.util.Optional;
+
 @Slf4j
 @RequiredArgsConstructor
 public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
@@ -26,7 +28,12 @@ public class LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
                                         Authentication authentication) {
         log.info("아이디-패스워드 Login 성공!");
         String username = extractUsername(authentication);
+
         String userTag = userRepository.findUserTagByUsername(username).toString();
+        Optional<String> userTagOpt = userRepository.findUserTagByUsername(username);
+        if (userTagOpt.isPresent()) {
+            userTag = userTagOpt.get();
+        }
         String accessToken = jwtService.createAccessToken(userTag);
         String refreshToken = jwtService.createRefreshToken();
 

--- a/src/main/java/kr/co/zeppy/user/dto/UserRegisterByUsernameResponse.java
+++ b/src/main/java/kr/co/zeppy/user/dto/UserRegisterByUsernameResponse.java
@@ -1,0 +1,22 @@
+package kr.co.zeppy.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserRegisterByUsernameResponse {
+
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String username;
+    private String nickname;
+    private String userTag;
+    private String imageUrl;
+}


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/loginByUsername -> develop
### 변경 사항
- 아이디 회원가입 후 바로 accessToken, refreshToken을 받아와 /login-by-username 거치지 않고 바로 토큰 사용 가능
- 닉네임 영소문자 10글자로 랜덤생성, 이미지 파일 default로 저장됨
- 현재 default 이미지는 아무생각 없이 내가 1번 프로필 사용자 이미지로 덮어써버린 이미지임 ... ㅎ
- 사용하지 않는 함수 (createAccessTokenByUsername, extractUsername 등) 삭제
### 테스트 결과 (optional)
- 사진 설명
(사진 업로드)
![image](https://github.com/SWM-AAA/backend_spring/assets/86220363/dfe3185b-a93c-45a5-9884-8e33b4d913a6)
-> 회원가입 후 Response Body에 담겨 있는 accessToken, refreshToken을 담아 사용하면 됩니다 !
![image](https://github.com/SWM-AAA/backend_spring/assets/86220363/2877f0af-0a3a-4a8c-a365-717e7564f215)
-> /login-by-username API 사용 시 토큰 갱신됨