### PR TITLE
[ZP-76] /register response body의 access token 삭제

### DIFF
--- a/src/main/java/kr/co/zeppy/user/controller/UserController.java
+++ b/src/main/java/kr/co/zeppy/user/controller/UserController.java
@@ -84,14 +84,15 @@ public class UserController {
             throws IOException {
 
         String newUserTag = userService.register(token, userRegisterRequest);
-        String accessToken = jwtService.createAccessToken(newUserTag);
+        jwtService.createAccessToken(newUserTag);
+
         Long userId = userRepository.findIdByUserTag(newUserTag)
                 .orElseThrow(() -> new ApplicationException(ApplicationError.USER_TAG_NOT_FOUND));
         String userImageUrl = userRepository.findImageUrlByUserTag(newUserTag)
                 .map(String::valueOf)
                 .orElseThrow(() -> new ApplicationException(ApplicationError.USER_IMAGE_URL_NOT_FOUND));
 
-        UserRegisterResponse userRegisterResponse = userService.userRegisterBody(accessToken, newUserTag, userId, userImageUrl);
+        UserRegisterResponse userRegisterResponse = userService.userRegisterBody(newUserTag, userId, userImageUrl);
 
         return ResponseEntity.ok(userRegisterResponse);
     }

--- a/src/main/java/kr/co/zeppy/user/dto/UserRegisterRequest.java
+++ b/src/main/java/kr/co/zeppy/user/dto/UserRegisterRequest.java
@@ -16,5 +16,5 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserRegisterRequest {
 
     private String nickname;
-    private MultipartFile profileimage;
+    private MultipartFile profileImage;
 }

--- a/src/main/java/kr/co/zeppy/user/dto/UserRegisterResponse.java
+++ b/src/main/java/kr/co/zeppy/user/dto/UserRegisterResponse.java
@@ -15,5 +15,4 @@ public class UserRegisterResponse {
     private Long userId;
     private String userTag;
     private String imageUrl;
-    private String accessToken;
 }

--- a/src/main/java/kr/co/zeppy/user/service/UserService.java
+++ b/src/main/java/kr/co/zeppy/user/service/UserService.java
@@ -124,7 +124,7 @@ public class UserService {
         User user = userRepository.findByUserTag(userTag)
                 .orElseThrow(() -> new ApplicationException(ApplicationError.USER_NOT_FOUND));
 
-        MultipartFile file = userRegisterRequest.getProfileimage();
+        MultipartFile file = userRegisterRequest.getProfileImage();
         String newUserTag = nickNameService.getUserTagFromNickName(userRegisterRequest.getNickname());
 
         String fileName = awsS3Uploader.newUpload(file
@@ -139,13 +139,12 @@ public class UserService {
         return newUserTag;
     }
 
-    public UserRegisterResponse userRegisterBody(String accessToken, String userTag, Long userId
+    public UserRegisterResponse userRegisterBody(String userTag, Long userId
         , String userImageUrl) {
 
         return UserRegisterResponse.builder()
                     .userId(userId)
                     .userTag(userTag)
-                    .accessToken(accessToken)
                     .imageUrl(userImageUrl)
                     .build();
     }

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -581,7 +581,7 @@ Authorization: Bearer token
 Host: zeppy.co.kr
 
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
-Content-Disposition: form-data; name=profileimage
+Content-Disposition: form-data; name=profileImage
 
 image content
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>

--- a/src/test/java/kr/co/zeppy/user/controller/UserControllerTest.java
+++ b/src/test/java/kr/co/zeppy/user/controller/UserControllerTest.java
@@ -67,7 +67,7 @@ public class UserControllerTest extends ApiDocument {
     private static final String USERTAG = "userTag";
     private static final String TOKEN = "token";
     private static final String IMAGEURL = "imageUrl";
-    private static final String PROFILE_IMAGE_NAME = "profileimage";
+    private static final String PROFILE_IMAGE_NAME = "profileImage";
     private static final String FILE_NAME = "filename.jpg";
     private static final String CONTENT_TYPE = "image/jpeg";
     private static final byte[] CONTENT = "image content".getBytes();
@@ -147,7 +147,7 @@ public class UserControllerTest extends ApiDocument {
         file = new MockMultipartFile(PROFILE_IMAGE_NAME, FILE_NAME, CONTENT_TYPE, CONTENT);
         userRegisterRequest = UserRegisterRequest.builder()
                 .nickname(NICKNAME)
-                .profileimage(file)
+                .profileImage(file)
                 .build();
 
         userInfoResponse = UserInfoResponse.builder()
@@ -166,7 +166,6 @@ public class UserControllerTest extends ApiDocument {
                 .userId(USER_LONG_ID)
                 .userTag(VALID_USER_TAG)
                 .imageUrl(FILE_NAME)
-                .accessToken(ACCESSTOKEN)
                 .build();
 
         userNicknameRequest = UserNicknameRequest.builder()
@@ -271,7 +270,7 @@ public class UserControllerTest extends ApiDocument {
 
     private ResultActions user_Register_Request() throws Exception {
         return mockMvc.perform(RestDocumentationRequestBuilders.multipart(API_VERSION + RESOURCE_PATH + "/register")
-                .file(PROFILE_IMAGE_NAME, userRegisterRequest.getProfileimage().getBytes())
+                .file(PROFILE_IMAGE_NAME, userRegisterRequest.getProfileImage().getBytes())
                 .header(AUTHORIZATION_HEADER, "Bearer " + TOKEN)
                 .param(NICKNAME, userRegisterRequest.getNickname())
                 .contentType(MediaType.MULTIPART_FORM_DATA));

--- a/src/test/java/kr/co/zeppy/user/service/UserServiceTest.java
+++ b/src/test/java/kr/co/zeppy/user/service/UserServiceTest.java
@@ -64,7 +64,7 @@ public class UserServiceTest {
     private static final Long USER_ID = 1L;
     private static final String FILE_NAME = "testFileName";
     private static final String IMAGE_URL = "testImageUrl";
-    private static final String PROFILE_IMAGE_NAME = "profileimage";
+    private static final String PROFILE_IMAGE_NAME = "profileImage";
     private static final String FILE_TYPE = "image/jpeg";
     private static final byte[] IMAGE_CONTENT = "image content".getBytes();
 
@@ -87,7 +87,7 @@ public class UserServiceTest {
         file = new MockMultipartFile(PROFILE_IMAGE_NAME, FILE_NAME, FILE_TYPE, IMAGE_CONTENT);
         userRegisterRequest = UserRegisterRequest.builder()
                 .nickname(NICKNAME)
-                .profileimage(file)
+                .profileImage(file)
                 .build();
 
         user = mock(User.class);


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [x] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feat/register -> develop
### 변경 사항
- register 후 response body에서 access token 제외
- profileimage -> profileImage 변수명 수정
### 테스트 결과 (optional)
- 사진 설명
(사진 업로드)
![image](https://github.com/SWM-AAA/backend_spring/assets/86220363/32f11055-ef69-49ff-8ff0-f6ba020630ab)
